### PR TITLE
Add convert method that takes the Java code as a string

### DIFF
--- a/scalagen/src/main/scala/com/mysema/scalagen/Converter.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Converter.scala
@@ -13,7 +13,7 @@
  */
 package com.mysema.scalagen
 
-import java.io.File
+import java.io.{File, ByteArrayInputStream}
 import japa.parser.JavaParser
 import japa.parser.ast.{ImportDeclaration, CompilationUnit}
 import org.apache.commons.io.FileUtils
@@ -70,7 +70,12 @@ class Converter(encoding: String, transformers: List[UnitTransformer]) {
       case e: Exception => throw new RuntimeException("Caught Exception for " + in.getPath, e) 
     }    
   }
-    
+  
+  def convert(javaSource: String): String = {
+    val compilationUnit = JavaParser.parse(new ByteArrayInputStream(javaSource.getBytes(encoding)), encoding)
+    toScala(compilationUnit)
+  }
+  
   def toScala(unit: CompilationUnit): String = {
     if (unit.getImports == null) {
       unit.setImports(new ArrayList[ImportDeclaration]())  

--- a/scalagen/src/test/scala/com/mysema/scalagen/ConverterTest.scala
+++ b/scalagen/src/test/scala/com/mysema/scalagen/ConverterTest.scala
@@ -32,4 +32,9 @@ class ConverterTest extends AbstractParserTest {
     assertTrue(new File("target/test2/scala/com/mysema/examples/Bean.scala").length > 0)
   }
 
+  @Test
+  def Convert_String_Has_Content {
+    assertTrue(Converter.instance.convert("class A {}").length > 0)
+  }
+  
 }


### PR DESCRIPTION
I'm making a Scala IDE plugin to convert Java to Scala, and it would be helpful to be able to pass the code in as a string rather than writing it out to a file (only to have scalagen read it in again).
