### PR TITLE
Update code to be compatible with scala 2.10

### DIFF
--- a/scalagen/src/main/scala/com/mysema/scala/BeanUtils.scala
+++ b/scalagen/src/main/scala/com/mysema/scala/BeanUtils.scala
@@ -19,7 +19,7 @@ import org.apache.commons.lang3.StringUtils
 object BeanUtils {
 
   def capitalize(name: String): String = {
-    if (name.length > 1 && name.charAt(1).isUpperCase) {
+    if (name.length > 1 && Character.isUpperCase(name.charAt(1))) {
        name
     } else {
        StringUtils.capitalize(name)

--- a/scalagen/src/main/scala/com/mysema/scalagen/Annotations.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Annotations.scala
@@ -15,16 +15,16 @@ package com.mysema.scalagen
 
 import japa.parser.ast.visitor._
 import java.util.ArrayList
+import japa.parser.ast.ImportDeclaration
+import japa.parser.ast.expr.NameExpr
 import japa.parser.ast.visitor.ModifierVisitorAdapter
 import UnitTransformer._
-
-object Annotations extends Annotations
 
 /**
  * Annotations turns Annotation type declarations into normal classes which extend
  * StaticAnnotation
  */
-class Annotations extends UnitTransformerBase {
+class Annotations(targetVersion: ScalaVersion) extends UnitTransformerBase {
   
   private val staticAnnotationType = new ClassOrInterface("StaticAnnotation")
   
@@ -34,6 +34,11 @@ class Annotations extends UnitTransformerBase {
     
   override def visit(n: AnnotationDecl, arg: CompilationUnit) = {
     // turns annotations into StaticAnnotation subclasses
+    if (targetVersion == Scala210) {
+      //StaticAnnotation was in the "scala" package in 2.9, so it was imported by default
+      //in scala 2.10, it was moved to the scala.annotation package, so we need an explicit import
+      arg.getImports().add(new ImportDeclaration(new NameExpr("scala.annotation.StaticAnnotation"), false, false))
+    }
     val clazz = new ClassOrInterfaceDecl()
     clazz.setName(n.getName)    
     clazz.setExtends(staticAnnotationType :: Nil)

--- a/scalagen/src/main/scala/com/mysema/scalagen/BeanProperties.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/BeanProperties.scala
@@ -51,8 +51,8 @@ class BeanProperties extends UnitTransformerBase with BeanHelpers {
     for ( (name, variable, field) <- fields) {
       var getter = getters(name)
       //t.getMembers.remove(getter)
-      t.setMembers(t.getMembers - getter)
-      setters.get(name).foreach { s => t.setMembers(t.getMembers - s) }
+      t.setMembers(t.getMembers.filterNot(_ == getter))
+      setters.get(name).foreach { s => t.setMembers(t.getMembers.filterNot(_ == s)) }
       
       // make field public
       val isFinal = field.getModifiers.isFinal

--- a/scalagen/src/main/scala/com/mysema/scalagen/CompanionObject.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/CompanionObject.scala
@@ -88,7 +88,7 @@ class CompanionObject extends UnitTransformer {
     
     val staticMembers = t.getMembers.filter(isStatic)
     if (!staticMembers.isEmpty) {
-      t.setMembers(t.getMembers -- staticMembers)
+      t.setMembers(t.getMembers.filterNot(staticMembers.contains))
       var companion = new ClassOrInterfaceDecl(OBJECT, false, t.getName)
       companion.setMembers(staticMembers)
       companion

--- a/scalagen/src/main/scala/com/mysema/scalagen/Constructors.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Constructors.scala
@@ -122,7 +122,7 @@ class Constructors extends UnitTransformerBase {
               copyAnnotationsAndModifiers(field, param)
               // remove field
               //field.getVariables.remove(variables(namedTarget.getName))
-              field.setVariables(field.getVariables - variables(namedTarget.getName))  
+              field.setVariables(field.getVariables.filterNot(_ == variables(namedTarget.getName)))  
             }            
           } else { // field = ?!?
             variables(namedTarget.getName).setInit(assign.getValue)              
@@ -147,7 +147,7 @@ class Constructors extends UnitTransformerBase {
           .foreach(copyAnnotationsAndModifiers(field,_))
         // remove field, as constructor parameter can be used
         //field.getVariables.remove(variables(fieldAccess.getField))
-        field.setVariables(field.getVariables - variables(fieldAccess.getField))
+        field.setVariables(field.getVariables.filterNot(_ == variables(fieldAccess.getField)))
          
       } else {
         // remove statement, put init to field

--- a/scalagen/src/main/scala/com/mysema/scalagen/Helpers.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Helpers.scala
@@ -81,10 +81,10 @@ trait Helpers {
       b.setStmts(b.getStmts ++ s)
     }
     def remove(s: Statement) {
-      b.setStmts(b.getStmts - s)
+      b.setStmts(b.getStmts.filterNot(_ == s))
     }
     def removeAll(s: List[Statement]) {
-      b.setStmts(b.getStmts -- s)
+      b.setStmts(b.getStmts.filterNot(s.contains))
     }
     def copy(): Block = {
       def block = new Block()

--- a/scalagen/src/main/scala/com/mysema/scalagen/Initializers.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Initializers.scala
@@ -49,7 +49,8 @@ class Initializers extends UnitTransformerBase {
       }
       
       // remove empty initializers
-      t.setMembers( t.getMembers -- initializers.filter(_.getBlock.isEmpty) )      
+      val emptyInitializerBlocks = initializers.filter(_.getBlock.isEmpty)
+      t.setMembers( t.getMembers.filterNot(emptyInitializerBlocks.contains) )      
     }
     t
   }

--- a/scalagen/src/main/scala/com/mysema/scalagen/Properties.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Properties.scala
@@ -49,15 +49,15 @@ class Properties extends UnitTransformerBase {
       var getter = getters(name)
       val body = getter.getBody
       if (getter.getModifiers.isAbstract) {
-        t.setMembers(t.getMembers - getter)
+        t.setMembers(t.getMembers.filterNot(_ == getter))
         field.removeModifier(PRIVATE)
       } else if (isReturnFieldStmt(body(0))) {
         //t.getMembers.remove(getter)
-        t.setMembers(t.getMembers - getter)
+        t.setMembers(t.getMembers.filterNot(_ == getter))
         field.setModifiers(getter.getModifiers)
       } else if (isLazyCreation(body,name)) {
         //t.getMembers.remove(getter)
-        t.setMembers(t.getMembers - getter)
+        t.setMembers(t.getMembers.filterNot(_ == getter))
         variable.setInit(getLazyInit(body))
         field.setModifiers(getter.getModifiers
           .addModifier(LAZY).addModifier(ModifierSet.FINAL))

--- a/scalagen/src/main/scala/com/mysema/scalagen/ScalaDumpVisitor.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/ScalaDumpVisitor.scala
@@ -331,7 +331,7 @@ class ScalaDumpVisitor extends VoidVisitor[ScalaDumpVisitor.Context] with Helper
     printTypeParameters(n.getTypeParameters, arg)
     var constr = getFirstConstructor(n.getMembers)
     if (constr != null) {
-      n.setMembers(n.getMembers - constr)
+      n.setMembers(n.getMembers.filterNot(_ == constr))
     }
     var superInvocation: Option[ExplicitConstructorInvocationStmt] = None
     if (constr != null) {

--- a/scalagen/src/main/scala/com/mysema/scalagen/ScalaVersion.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/ScalaVersion.scala
@@ -1,0 +1,15 @@
+package com.mysema.scalagen
+
+sealed trait ScalaVersion
+
+case object Scala29 extends ScalaVersion
+
+case object Scala210 extends ScalaVersion
+
+object ScalaVersion {
+  def getVersion(versionNumberString: String) = {
+    if (versionNumberString.startsWith("2.9.")) Scala29
+    else if (versionNumberString.startsWith("2.10.")) Scala210
+    else throw new IllegalArgumentException("Unsupported scala version: " + versionNumberString)
+  }
+}

--- a/scalagen/src/main/scala/com/mysema/scalagen/SerialVersionUID.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/SerialVersionUID.scala
@@ -41,10 +41,10 @@ class SerialVersionUID extends UnitTransformerBase {
        
     if (varAndField != null) {
       //varAndField._2.getVariables.remove(varAndField._1)
-      varAndField._2.setVariables(varAndField._2.getVariables - varAndField._1)
+      varAndField._2.setVariables(varAndField._2.getVariables.filterNot(_ == varAndField._1))
       if (varAndField._2.getVariables.isEmpty) {
         //n.getMembers.remove(varAndField._2)
-        n.setMembers( n.getMembers - varAndField._2 )
+        n.setMembers( n.getMembers.filterNot(_ == varAndField._2) )
       }
       val value = varAndField._1.getInit
       n.setAnnotations(new SingleMemberAnnotation("SerialVersionUID", value) :: n.getAnnotations)

--- a/scalagen/src/test/scala/com/mysema/scala/CompileTestUtils.scala
+++ b/scalagen/src/test/scala/com/mysema/scala/CompileTestUtils.scala
@@ -1,7 +1,6 @@
 package com.mysema.scala
 
 import scala.tools.nsc._
-import scala.tools.nsc.InterpreterResults._
 import scala.io.Source.fromFile
 import java.io.File
 
@@ -37,7 +36,10 @@ trait CompileTestUtils {
     val interpreter = new Interpreter(env, interpreterWriter)
     try {
       val result = interpreter.interpret(source.replaceAll("package ", "import "))
-      if (result != Success) {
+      //we have to compare as a string because of an incompatibility between 2.9 and 2.10:
+      //in 2.9, result is scala.tools.nsc.InterpreterResults
+      //in 2.10, result is scala.tools.nsc.interpreter.Results
+      if (result.toString != "Success") {
         throw new AssertionError("Compile failed, interpreter output:\n" + out.toString("utf-8"))
       }
     } finally {

--- a/scalagen/src/test/scala/com/mysema/scalagen/AbstractParserTest.scala
+++ b/scalagen/src/test/scala/com/mysema/scalagen/AbstractParserTest.scala
@@ -38,6 +38,6 @@ abstract class AbstractParserTest {
   
   def toScala[T](implicit mf: Manifest[T]): String = toScala(getCompilationUnit(mf.erasure))
   
-  def toScala(unit: CompilationUnit): String = Converter.instance.toScala(unit)
+  def toScala(unit: CompilationUnit): String = Converter.getInstance().toScala(unit)
   
 }


### PR DESCRIPTION
This is mainly a change to the source code of scalagen itself, the largest change being the removal of the - and -- operators from List.

There is also a small change in the generated source, which requires knowledge of whether we are targetting scala 2.9 or 2.10. StaticAnnotation in scala has moved to a package that is not imported by default, so if we're targetting 2.10 we must add an explicit import.

The change to Annotations doesn't need a new test because it is already covered by ScalaCompilationTest (the annotations Config.java and QueryDelegate.java would fail to compile under 2.10 without this change).
