### PR TITLE
Fix loop condition and early return conversion (find/map)

### DIFF
--- a/scalagen/src/main/scala/com/mysema/scalagen/ModifierVisitor.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/ModifierVisitor.scala
@@ -18,6 +18,7 @@ import japa.parser.ast.`type`.VoidType
 import japa.parser.ast.`type`.WildcardType
 import japa.parser.ast.visitor.GenericVisitor
 import java.util.{ArrayList, Collections}
+import com.mysema.scalagen.ast.BeginClosureExpr
 
 /**
  * 
@@ -346,7 +347,10 @@ abstract class ModifierVisitor[A] extends GenericVisitor[Node, A] {
     rv
   }
 
-  def visit(n: NameExpr, arg: A): Node = new NameExpr(visitName(n.getName, arg))
+  def visit(n: NameExpr, arg: A): Node = n match {
+    case closure: BeginClosureExpr => closure
+    case _ => new NameExpr(visitName(n.getName, arg))
+  }
 
   def visit(n: NormalAnnotationExpr, arg: A): Node = {
     val rv = new NormalAnnotationExpr()

--- a/scalagen/src/main/scala/com/mysema/scalagen/ScalaDumpVisitor.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/ScalaDumpVisitor.scala
@@ -25,6 +25,7 @@ import java.util.Iterator
 import java.util.List
 import org.apache.commons.lang3.StringUtils
 import japa.parser.ast.visitor.GenericVisitorAdapter
+import com.mysema.scalagen.ast.BeginClosureExpr
 
 object ScalaDumpVisitor {
 
@@ -209,14 +210,21 @@ class ScalaDumpVisitor(settings: ConversionSettings) extends VoidVisitor[ScalaDu
     if (args != null) {
       val i = args.iterator()
       while (i.hasNext) {
-        var e = i.next()
-        e.accept(this, arg)
-        if (i.hasNext) {
-          printer.print(", ")
-          if (settings.splitLongLines && printer.lineLength > NL_THRESHOLD) {
-            printer.printLn()
-            printer.print("  ")
+        i.next() match {
+          case closure: BeginClosureExpr => {
+            printer.print(closure.params + " => ")
           }
+          case e => {
+            e.accept(this, arg)
+            if (i.hasNext) {
+              printer.print(", ")
+            }
+          }
+        }
+        
+        if (i.hasNext && settings.splitLongLines && printer.lineLength > NL_THRESHOLD) {
+          printer.printLn()
+          printer.print("  ")
         }
       }
     }

--- a/scalagen/src/main/scala/com/mysema/scalagen/ast/BeginClosureExpr.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/ast/BeginClosureExpr.scala
@@ -1,0 +1,7 @@
+package com.mysema.scalagen.ast
+
+import japa.parser.ast.expr.NameExpr
+
+class BeginClosureExpr(params: String) extends NameExpr(params) {
+  def params = getName
+}

--- a/scalagen/src/test/scala/com/mysema/examples/Loop.java
+++ b/scalagen/src/test/scala/com/mysema/examples/Loop.java
@@ -2,10 +2,28 @@ package com.mysema.examples;
 
 public class Loop {
 
-    boolean method(String str) {
+    boolean condition_and_early_return_dont_contain_b(String str) {
+        for (String b : java.util.Arrays.asList("a", "b")) {
+            if (str.startsWith("a")) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    boolean condition_and_early_return_contain_b_once(String str) {
         for (String b : java.util.Arrays.asList("a", "b")) {
             if (str.startsWith(b)) {
-                return true;
+                return b.length() > 0;
+            }
+        }
+        return false;
+    }
+    
+    boolean condition_and_early_return_contain_b_multiple_times(String str) {
+        for (String b : java.util.Arrays.asList("a", "b")) {
+            if (str.startsWith(b) && b.length() < 10) {
+                return b.length() > 0 || b.length() < 15;
             }
         }
         return false;

--- a/scalagen/src/test/scala/com/mysema/scalagen/ScalaCompilationTest.scala
+++ b/scalagen/src/test/scala/com/mysema/scalagen/ScalaCompilationTest.scala
@@ -43,7 +43,7 @@ class ScalaCompilationTest extends AbstractParserTest with CompileTestUtils {
     failures.foreach { case (n,m) => System.err.println(n + " => " + m)}
     
     // known failures
-    val filtered = failures.-("Loop.java").-("Constructors3.java")
+    val filtered = failures.-("Constructors3.java")
     
     assertTrue(
       failures.size + " of " + resources.size + " failures : " + failures.keys.mkString(", "), 

--- a/scalagen/src/test/scala/com/mysema/scalagen/SerializationTest.scala
+++ b/scalagen/src/test/scala/com/mysema/scalagen/SerializationTest.scala
@@ -192,6 +192,17 @@ class SerializationTest extends AbstractParserTest {
     val sources = toScala[LazyInitBeanAccessor]
     assertContains(sources, "lazy val value = \"XXX\"")
   }
+  
+  @Test
+  def Loop {
+    val sources = toScala[Loop]
+    assertContains(sources, """.find(_ => str.startsWith("a"))""")
+    assertContains(sources, ".map(_ => true)")
+    assertContains(sources, ".find(str.startsWith(_))")
+    assertContains(sources, ".map(_.length > 0)")
+    assertContains(sources, ".find(b => str.startsWith(b) && b.length < 10)")
+    assertContains(sources, ".map(b => b.length > 0 || b.length < 15)")
+  }
 
   @Test
   def Modifiers {


### PR DESCRIPTION
The previous code only handled the case where the variable being looped over is used exactly once in a condition (converted to find) or an early return (converted to map). This handles all cases.
It's not the greatest since I'm creating a new class that extends NameExpr and has to be dealt with as a special case in ModifierVisitor, but there's no way to add new expressions without changing javaparser (and scala expressions/nodes shouldn't be in there).
