### PR TITLE
Make splitting long lines optional

### DIFF
--- a/scalagen/src/main/scala/com/mysema/scalagen/ConversionSettings.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/ConversionSettings.scala
@@ -1,0 +1,7 @@
+package com.mysema.scalagen
+
+case class ConversionSettings(splitLongLines: Boolean = true)
+
+object ConversionSettings {
+  def defaultSettings = ConversionSettings()
+}

--- a/scalagen/src/main/scala/com/mysema/scalagen/Converter.scala
+++ b/scalagen/src/main/scala/com/mysema/scalagen/Converter.scala
@@ -102,17 +102,17 @@ class Converter(encoding: String, transformers: List[UnitTransformer]) {
     }    
   }
   
-  def convert(javaSource: String): String = {
+  def convert(javaSource: String, settings: ConversionSettings = ConversionSettings()): String = {
     val compilationUnit = JavaParser.parse(new ByteArrayInputStream(javaSource.getBytes(encoding)), encoding)
-    toScala(compilationUnit)
+    toScala(compilationUnit, settings)
   }
   
-  def toScala(unit: CompilationUnit): String = {
+  def toScala(unit: CompilationUnit, settings: ConversionSettings = ConversionSettings()): String = {
     if (unit.getImports == null) {
       unit.setImports(new ArrayList[ImportDeclaration]())  
     }    
     val transformed = transformers.foldLeft(unit) { case (u,t) => t.transform(u) }    
-    var visitor = new ScalaDumpVisitor()
+    var visitor = new ScalaDumpVisitor(settings)
     transformed.accept(visitor, new ScalaDumpVisitor.Context())
     visitor.getSource
   }

--- a/scalagen/src/test/scala/com/mysema/examples/LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName.java
+++ b/scalagen/src/test/scala/com/mysema/examples/LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName.java
@@ -1,0 +1,32 @@
+package com.mysema.examples;
+
+public class LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName extends LongClassToExtendAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+	LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName x = new LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName(444, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+	
+	public LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName(int... nums) {
+	}
+	
+	public LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName(int a, int b, int c, int d, int e) {
+		this(a, b, c, d, e, 1, 2, 3, 4, 5);
+	}
+	
+	public void a(int... nums) {
+		if ("very long condition ........................".length() > 0 || "other long condition".length() > 0) {
+			a(555, 2, 3, 4, 5, 6, 7, 8, 9);
+		}
+		int[] aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = nums;
+		for (int n : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {
+			if ("long condition goes here ........................".length() > 0) {
+				System.out.println(n);
+			}
+		}
+	}
+}
+
+class LongClassToExtendAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+	public LongClassToExtendAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa() {
+	}
+	
+	public LongClassToExtendAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(int... nums) {
+	}
+}

--- a/scalagen/src/test/scala/com/mysema/scalagen/AbstractParserTest.scala
+++ b/scalagen/src/test/scala/com/mysema/scalagen/AbstractParserTest.scala
@@ -38,6 +38,11 @@ abstract class AbstractParserTest {
   
   def toScala[T](implicit mf: Manifest[T]): String = toScala(getCompilationUnit(mf.erasure))
   
+  def toScala[T](settings: ConversionSettings)(implicit mf: Manifest[T]): String =
+    toScala(getCompilationUnit(mf.erasure), settings)
+  
   def toScala(unit: CompilationUnit): String = Converter.getInstance().toScala(unit)
+  
+  def toScala(unit: CompilationUnit, settings: ConversionSettings): String = Converter.getInstance().toScala(unit, settings)
   
 }

--- a/scalagen/src/test/scala/com/mysema/scalagen/SerializationTest.scala
+++ b/scalagen/src/test/scala/com/mysema/scalagen/SerializationTest.scala
@@ -178,6 +178,16 @@ class SerializationTest extends AbstractParserTest {
   }
 
   @Test
+  def LongLines {
+    val sources = toScala[LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName](ConversionSettings(splitLongLines = false))
+    assertContains(sources, "class LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName(nums: Int*) extends LongClassToExtendAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {")
+    assertContains(sources, "var x: LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName = new LongLinesIncludingAVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongClassName(444, 2, 3, 4, 5, 6, 7, 8, 9, 10)")
+    assertContains(sources, "def this(a: Int, b: Int, c: Int, d: Int, e: Int)")
+    assertContains(sources, """if ("very long condition ........................".length > 0 || "other long condition".length > 0)""")
+    assertContains(sources, """for (n <- aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa if "long condition goes here ........................".length > 0)""")
+  }
+
+  @Test
   def LazyInitBeanAccessor {
     val sources = toScala[LazyInitBeanAccessor]
     assertContains(sources, "lazy val value = \"XXX\"")


### PR DESCRIPTION
The motivation for this is that in the java to scala plugin, the output is always in eclipse which means that you can hit Ctrl+Shift+F to format it according to the preferences you've set up. However, that formatting will preserve line breaks, which means you would have to remove line breaks manually if you prefer lines be split at a longer length.
